### PR TITLE
Miscellaneous fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+---
+
 ### Disable line length constraint
 Metrics/LineLength:
   Max: 140
@@ -9,6 +11,6 @@ Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
 ### Align hashes as a table
-Style/AlignHash:
+Layout/AlignHash:
   EnforcedColonStyle: table
   EnforcedHashRocketStyle: table

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,9 @@ Metrics/LineLength:
   Max: 140
 
 ### Comma after each line in a list
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
 ### Align hashes as a table

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
+---
+
 rvm:
-  - 2.1.0
   - 2.3.1
 script:
   - bundle exec rake travis:ci

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'berkshelf'
 gem 'chefspec'
-gem 'rubocop'
+gem 'rubocop', '~> 0.66.0'
 gem 'serverspec'
 
 gem 'chef', '~> 12.0'


### PR DESCRIPTION
* stick Rubocop version (to prevent further break without notice)
* fix Rubocop conf issue with latest version
* remove Ruby 2.1 from CI (we don't use this version anymore)